### PR TITLE
Readonly get new mail

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -428,7 +428,7 @@ class Mailbox(models.Model):
         if since is None:
             since = now() - timedelta(days=INITIAL_IMPORT_LOOKBACK_DAYS)
 
-        for message in connection.get_new_message_ro(since=since):
+        for message in connection.get_message_ro(since=since):
             msg = self.process_incoming_message(message)
             if not msg is None:
                 yield msg

--- a/django_mailbox/transports/generic.py
+++ b/django_mailbox/transports/generic.py
@@ -25,5 +25,5 @@ class GenericFileMailbox(EmailTransport):
         repository.flush()
         repository.unlock()
 
-    def get_new_message_ro(self, since=None):
-        raise NotImplementedError("GenericFileMailbox.get_new_message_ro not implemented!")
+    def get_message_ro(self, since=None):
+        raise NotImplementedError("GenericFileMailbox.get_message_ro not implemented!")

--- a/django_mailbox/transports/generic.py
+++ b/django_mailbox/transports/generic.py
@@ -24,3 +24,6 @@ class GenericFileMailbox(EmailTransport):
             yield message
         repository.flush()
         repository.unlock()
+
+    def get_new_message_ro(self, since=None):
+        raise NotImplementedError("GenericFileMailbox.get_new_message_ro not implemented!")

--- a/django_mailbox/transports/imap.py
+++ b/django_mailbox/transports/imap.py
@@ -111,7 +111,7 @@ class ImapTransport(EmailTransport):
         self.server.expunge()
         return
 
-    def get_new_message_ro(self, since):
+    def get_message_ro(self, since):
         """Read-only version of `get_message`. Uses a timestamp to fetch only messages
         originating later than `since` parameter.
         """

--- a/django_mailbox/transports/pop3.py
+++ b/django_mailbox/transports/pop3.py
@@ -43,5 +43,5 @@ class Pop3Transport(EmailTransport):
         self.server.quit()
         return
 
-    def get_new_message_ro(self, since=None):
-        raise NotImplementedError("Pop3Transport.get_new_message_ro not implemented!")
+    def get_message_ro(self, since=None):
+        raise NotImplementedError("Pop3Transport.get_message_ro not implemented!")

--- a/django_mailbox/transports/pop3.py
+++ b/django_mailbox/transports/pop3.py
@@ -42,3 +42,6 @@ class Pop3Transport(EmailTransport):
             self.server.dele(i + 1)
         self.server.quit()
         return
+
+    def get_new_message_ro(self, since=None):
+        raise NotImplementedError("Pop3Transport.get_new_message_ro not implemented!")


### PR DESCRIPTION
This completes the django-mailbox side of [#25](https://github.com/iotalabscompany/allie.ai/issues/25).  Which now a readonly fetching mechanism is used to receive emails from the inboxes.