### PR TITLE
Enable folder function for gmail

### DIFF
--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -430,9 +430,9 @@ class Mailbox(models.Model):
         if not connection:
             return
 
-        # since = self.last_polling
-        # if since is None:
-        since = now() - timedelta(days=INITIAL_IMPORT_LOOKBACK_DAYS)
+        since = self.last_polling
+        if since is None:
+            since = now() - timedelta(days=INITIAL_IMPORT_LOOKBACK_DAYS)
 
         for message in connection.get_message_ro(since=since):
             msg = self.process_incoming_message(message)

--- a/django_mailbox/models.py
+++ b/django_mailbox/models.py
@@ -216,7 +216,8 @@ class Mailbox(models.Model):
                 self.location,
                 port=self.port if self.port else None,
                 ssl=True,
-                archive=self.archive
+                archive=self.archive,
+                folder=self.folder,
             )
             conn.connect(self.username, self.password)
         elif self.type == 'pop3':
@@ -429,9 +430,9 @@ class Mailbox(models.Model):
         if not connection:
             return
 
-        since = self.last_polling
-        if since is None:
-            since = now() - timedelta(days=INITIAL_IMPORT_LOOKBACK_DAYS)
+        # since = self.last_polling
+        # if since is None:
+        since = now() - timedelta(days=INITIAL_IMPORT_LOOKBACK_DAYS)
 
         for message in connection.get_message_ro(since=since):
             msg = self.process_incoming_message(message)

--- a/django_mailbox/transports/gmail.py
+++ b/django_mailbox/transports/gmail.py
@@ -14,9 +14,7 @@ class GmailImapTransport(ImapTransport):
             self._connect_oauth(username)
         except (TypeError, ValueError) as e:
             logger.warning("Couldn't do oauth2 because %s" % e)
-            self.server = self.transport(self.hostname, self.port)
-            typ, msg = self.server.login(username, password)
-            self.server.select()
+            super().connect(username, password)
 
     def _connect_oauth(self, username):
         # username should be an email address that has already been authorized
@@ -54,4 +52,7 @@ class GmailImapTransport(ImapTransport):
         )
         self.server = self.transport(self.hostname, self.port)
         self.server.authenticate('XOAUTH2', lambda x: auth_string)
-        self.server.select()
+        if self.folder:
+            self.server.select(self.folder)
+        else:
+            self.server.select()


### PR DESCRIPTION
This enables using the `folder=` option on the end of mailbox uris so we can add the `[Gmail]/All Mail` folder to our oauthed accounts. This will now pull in inbound and outbound emails, creating proper threads between the `Message` objects.